### PR TITLE
feat: added film component for videos

### DIFF
--- a/src/app/components/FeatureFilmSection.tsx
+++ b/src/app/components/FeatureFilmSection.tsx
@@ -1,12 +1,18 @@
 import Button from "../components/Button";
+import Film from "./Film";
 import LABELS from "../constants/labels";
 
 export default function FeatureFilmSection() {
   return (
-    <div className="bg-sand w-full h-screen flex flex-col justify-center items-center">
+    <div className="bg-sand w-full  flex flex-col justify-center items-center">
       <h2 className="text-mosswood font-bold p-4 text-3xl">
         {LABELS.featureFilm.title}
       </h2>
+      <div className="p-4 flex flex-col w-full">
+        <Film videoId="1004015252" />
+        <Film videoId="1019498597" />
+        <Film videoId="1004931664" />
+      </div>
       <Button />
     </div>
   );

--- a/src/app/components/Film.tsx
+++ b/src/app/components/Film.tsx
@@ -1,0 +1,12 @@
+export default function Film({ videoId }: { videoId: string }) {
+  return (
+    <div className="aspect-video w-full max-w-4xl mx-auto my-6">
+      <iframe
+        src={`https://player.vimeo.com/video/${videoId}`}
+        allow="autoplay; fullscreen; picture-in-picture"
+        allowFullScreen
+        className="w-full h-full rounded-2xl shadow-lg"
+      ></iframe>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces the `<Film />` component. 

This component takes a `videoId` and displays the video with that id from Vimeo.

<img width="1250" alt="Screenshot 2025-05-15 at 6 14 16 PM" src="https://github.com/user-attachments/assets/1425b670-090d-446f-89a2-f4d2c50f5b4b" />
