### PR TITLE
fix: bio is now mobile adaptive. Added contact link (PF-13-bio-mobile)

### DIFF
--- a/src/app/components/Bio.tsx
+++ b/src/app/components/Bio.tsx
@@ -1,34 +1,28 @@
 import Image from "next/image";
+import Link from "next/link";
 import BioPic from "@/../public/damian.jpeg";
 import Button from "./Button";
+import LABELS from "../constants/labels";
 
 export default function Bio() {
   return (
-    <div className="flex flex-row w-full items-center justify-center bg-mosswood text-sand">
-      <div className="basis-1/2 flex items-center justify-center">
-        <Image src={BioPic} alt="Damian Padilla" />
+    <div className="flex flex-col md:flex-row w-full items-center justify-center bg-mosswood text-sand py-4">
+      <div className="basis-1/2 flex items-center justify-center p-4">
+        <Image
+          src={BioPic}
+          alt="Damian Padilla"
+          className="w-64 md:w-80 h-auto rounded-xl "
+        />
       </div>
-      <div className="basis-1/2 flex items-center justify-center flex-col gap-4 px-16">
-        <h1 className="text-4xl">Meet your videographer</h1>
-        <p className="text-lg">
-          My name is Damian Padilla and my journey in wedding videography began
-          with a deep-seated passion for storytelling. I believe that a wedding
-          is more than an event; it’s a narrative of love commitment, and the
-          beginning of a beautiful journey together.
-        </p>
-        <p className="text-lg">
-          That’s why at Parallax Films, your love story is my priority. I work
-          closely with you to understand your vision, your personalities, and
-          your unique love story. This personalized approach allows me to create
-          wedding films that are a tru reflection of you as a couple, ensuring
-          that your memories are preserved for a life time.
-        </p>
-        <p className="text-lg">
-          I would be honored to be part of your journey, capturing the magic of
-          your love story on film.
-        </p>
+      <div className="basis-1/2 flex items-center justify-center flex-col gap-4 px-4 lg:px-6 py-4">
+        <h1 className="text-4xl text-center">{LABELS.bio.title}</h1>
+        <p className="text-lg md:text-sm lg:text-lg">{LABELS.bio.paragraph1}</p>
+        <p className="text-lg md:text-sm lg:text-lg">{LABELS.bio.paragraph2}</p>
+        <p className="text-lg md:text-sm lg:text-lg">{LABELS.bio.paragraph3}</p>
 
-        <Button color="sand"> Let's Talk</Button>
+        <Link href={"/contact"}>
+          <Button color="sand">{LABELS.bio.button}</Button>
+        </Link>
       </div>
     </div>
   );

--- a/src/app/constants/labels.ts
+++ b/src/app/constants/labels.ts
@@ -1,5 +1,3 @@
-import test from "node:test";
-
 const LABELS = {
   intro: {
     title: "Capturing the Moments That Make Your Day Unforgettable",
@@ -56,6 +54,16 @@ const LABELS = {
       review:
         "We gave our vision of a documentary style Highlight Video Drone Service and received so much more than that!! We got our video on time and brought us to tears when we watched it! Couldn’t believe he was able to capture our venue to make it look so dreamy and amazing. Guided us on how to pose, something that’s important to me. Definitely something we’ll look back when we’re old to relive the moment! So many beautiful candid shots of not only us but our dearest family!! Very professional and easy to work with. Thank you so much!! ",
     },
+  },
+  bio: {
+    title: "Meet Your Videographer",
+    paragraph1:
+      "My name is Damian Padilla and my journey in wedding videography began with a deep-seated passion for storytelling. I believe that a wedding is more than an event; it’s a narrative of love, commitment, and the beginning of a beautiful journey together.",
+    paragraph2:
+      "That’s why at Parallax Films, your love story is my priority. I work closely with you to understand your vision, your personalities, and your unique love story. This personalized approach allows me to create wedding films that are a true reflection of you as a couple, ensuring that your memories are preserved for a lifetime.",
+    paragraph3:
+      "I would be honored to be part of your journey, capturing the magic of your love story on film.",
+    button: "Let's Talk",
   },
 };
 


### PR DESCRIPTION
In this PR I updated the design so that the bio section is mobile adaptive. I also added the title and paragraphs to the `LABELS` . Lastly I added a `Link` so that the 'Let's Talk' button routes to the `/contact` page.

Mobile View:
<img width="492" height="857" alt="Screenshot 2025-08-03 at 12 40 05 AM" src="https://github.com/user-attachments/assets/44aa34e0-5ecb-421c-bce0-48697a8b28e9" />

Desktop View:
<img width="1398" height="483" alt="Screenshot 2025-08-03 at 12 40 22 AM" src="https://github.com/user-attachments/assets/2ca7ab76-9030-4e4d-9a4d-dfff653261a5" />
